### PR TITLE
Remove (setq debug-on-error t)

### DIFF
--- a/vmd-mode.el
+++ b/vmd-mode.el
@@ -102,7 +102,6 @@ The optional ARGS argument is needed as this function is added to the
   (if vmd-mode
       (if vmd-binary-path
           (progn
-            (setq debug-on-error t)
             (add-hook 'after-change-functions 'vmd-mode-refresh nil t)
             (add-hook 'kill-buffer-hook 'vmd-mode-delete-temp nil t)
             (vmd-mode-start-vmd-process)


### PR DESCRIPTION
After spending a while trying to figure out why my emacs config magically set this, I finally traced it back to `vmd-mode`. If users want to debug, they can do so themselves, but a library should never set this.