### PR TITLE
Improvements: fix byte-compiler and checkdoc warnings.

### DIFF
--- a/vmd-mode.el
+++ b/vmd-mode.el
@@ -18,6 +18,7 @@
 ;; buffer, and performance is very good.
 
 ;;; Code:
+(require 'json)                         ; use `json-read-object'
 
 (defvar-local vmd-process nil
   "Handle to the inferior vmd process")
@@ -30,11 +31,13 @@
 (defgroup vmd nil
   "Fast Github-flavored Markdown preview using a vmd subprocess."
   :prefix "vmd-"
-  :group 'text)
+  :group 'text
+  :group 'markdown)
 
 (defcustom vmd-binary-path (executable-find "vmd")
-  "Path to your vmd binary."
-  :group 'vmd)
+  "Path to your vmd binary, or nil if vmd not available."
+  :group 'vmd
+  :type 'directory)
 
 
 ;; GitHub emojis
@@ -70,20 +73,22 @@ See https://developer.github.com/v3/emojis/"
   "Emoji for GitHub.")
 
 (defun vmd-mode-start-vmd-process ()
-  "Start an asynchronous `vmd' process to generate the `buffer-file-name' file."
+  "Start an asynchronous `vmd' process to generate the temporary work file."
+  ;; Work file name := current buffer file name and append ".temp" to it.
   (progn
     (setq vmd-copy-file (concat buffer-file-name ".temp"))
     (copy-file buffer-file-name vmd-copy-file "overwrite")
     (setq vmd-process (start-process "vmd" "vmd" vmd-binary-path vmd-copy-file))))
 
 (defun vmd-mode-delete-temp (&rest _args)
+  "Cleanup when buffer is killed."
   (progn (message "VMD-Mode deleting file: %s" vmd-copy-file)
          (if (file-exists-p vmd-copy-file)
              (delete-file vmd-copy-file))
          (message "VMD-Mode removing hook: 'kill-buffer-hook")
-         (remove-hook 'kill-buffer-hook 'vmd-mode-delete-temp t)
+         (remove-hook 'kill-buffer-hook (function vmd-mode-delete-temp) t)
          (message "VMD-Mode removing hook: 'after-change-functions")
-         (remove-hook 'after-change-functions 'vmd-mode-refresh t)
+         (remove-hook 'after-change-functions (function vmd-mode-refresh) t)
          (if vmd-process
              (progn
                (delete-process vmd-process)
@@ -99,14 +104,14 @@ The optional ARGS argument is needed as this function is added to the
 (define-minor-mode vmd-mode
   "Live Markdown preview with `vmd'."
   :lighter " vmd"
-  (if vmd-mode
+  (when vmd-mode
       (if vmd-binary-path
           (progn
-            (add-hook 'after-change-functions 'vmd-mode-refresh nil t)
-            (add-hook 'kill-buffer-hook 'vmd-mode-delete-temp nil t)
+            (add-hook 'after-change-functions (function vmd-mode-refresh) nil t)
+            (add-hook 'kill-buffer-hook (function vmd-mode-delete-temp) nil t)
             (vmd-mode-start-vmd-process)
             (vmd-mode-refresh))
-        (user-error "You need to have `vmd' installed in your environment PATH."))))
+        (user-error "You need to have `vmd' installed in your environment PATH"))))
 
 (provide 'vmd-mode)
 


### PR DESCRIPTION
- add require json: json-read-object is defined in built-in json.
- defcustom vmd-binary-path now has a type which will accept only valid
  directory paths when used types them. If vmd executable is not found
  it will be nil and that will conflict with the type preventing saving
  the custom value, but that's probably a good thing.
  Anyway there's nothing else in the group.
- The group is also a child of markdown group, like other packages that
  extend markdown.
- Improved byte compilation ability with the use of `function'.
- Use `when' in `vmd-mode' instead of the top-level if since there's no
  alternate branch. Should there be one?  Allowing vmd-mode to be toggled?
  I did not do that here, keeping the code behaviour the same.
- Add missing docstring to `vmd-mode-delete-temp'.
- Removed trailing period in `user-error' as required by Emacs guideline.
  I never really understood/agreed with that and often put a '!' at the
  end of these strings to go around the checkdoc warning, but didn't do it
  here.
- Also modified `vmd-mode-start-vmd-process' docstring to prevent checkdoc
  warning.